### PR TITLE
Add check for portage tree location

### DIFF
--- a/mkstage4.sh
+++ b/mkstage4.sh
@@ -143,12 +143,19 @@ EXCLUDES="\
 --exclude=${TARGET}run/* \
 --exclude=${TARGET}sys/* \
 --exclude=${TARGET}tmp/* \
---exclude=${TARGET}usr/portage/* \
 --exclude=${TARGET}var/lock/* \
 --exclude=${TARGET}var/log/* \
 --exclude=${TARGET}var/run/* \
 --exclude=${TARGET}var/lib/docker/*"
 
+# Exclude the one, exisiting portage directory, since it moved from /usr to /var/db
+if [ -d ${TARGET}var/db/repos/gentoo ]; then
+  EXCLUDES+=" --exclude=${TARGET}var/db/repos/gentoo/*"
+fi
+
+if [ -d ${TARGET}usr/portage ]; then
+  EXCLUDES+=" --exclude=${TARGET}usr/portage/*"
+fi
 
 EXCLUDES+=$USER_EXCL
 


### PR DESCRIPTION
Portage tree moved from /usr to /var/db/repos
Added check for /var/db/repos/gentoo and /usr/portage to be directories and exclude the existing one(s)
Custom repos will not be ignored, but included unless specified manually.